### PR TITLE
Fix Attributer

### DIFF
--- a/src/components/AttributorFields/index.js
+++ b/src/components/AttributorFields/index.js
@@ -35,14 +35,14 @@ export default function Lead ({returnUrl}) {
     <>
         <input type="hidden" name="retURL" value={returnUrl} />
 
-        <input type="hidden" name="channel" value={attributorData.drillData.channel} />
-        <input type="hidden" name="drillDown1" value={attributorData.drillData.drillDown1} />
-        <input type="hidden" name="drillDown2" value={attributorData.drillData.drillDown2} />
-        <input type="hidden" name="drillDown3" value={attributorData.drillData.drillDown3} />
-        <input type="hidden" name="drillDown4" value={attributorData.drillData.drillDown4} />
-        <input type="hidden" name="gclid" value={attributorData.gclid} />
-        <input type="hidden" name="landingpage" value={attributorData.landing_url} />
-        <input type="hidden" name="landingpagegroup" value={attributorData.landing_page_group} />
+        <input type="hidden" name="utm-channel" value={attributorData.drillData.channel} />
+        <input type="hidden" name="utm-drillDown1" value={attributorData.drillData.drillDown1} />
+        <input type="hidden" name="utm-drillDown2" value={attributorData.drillData.drillDown2} />
+        <input type="hidden" name="utm-drillDown3" value={attributorData.drillData.drillDown3} />
+        <input type="hidden" name="utm-drillDown4" value={attributorData.drillData.drillDown4} />
+        <input type="hidden" name="utm-gclid" value={attributorData.gclid} />
+        <input type="hidden" name="utm-landingpage" value={attributorData.landing_url} />
+        <input type="hidden" name="utm-landingpagegroup" value={attributorData.landing_page_group} />
     </>
   )
 }

--- a/src/components/AttributorFields/index.js
+++ b/src/components/AttributorFields/index.js
@@ -1,0 +1,52 @@
+import React, { useEffect, useRef, useState } from "react";
+import PropTypes from "prop-types"
+
+export default function Lead ({returnUrl}) {
+  const intervalRef = useRef();
+  const [attributorData, setAttributorData] = useState(undefined);
+
+  useEffect(() => {
+
+    if (typeof document !== "undefined") {
+        if (document.FlareTrk) {
+            setAttributorData(document.FlareTrk.getData())
+        } else {
+            intervalRef.current = setInterval(() => {
+                if (document.FlareTrk && intervalRef.current) {
+                    setAttributorData(document.FlareTrk.getData())
+                    clearInterval(intervalRef.current);
+                } else {
+                    console.warn(`FlareTrk library not loaded, retrying in 100ms`);
+                }
+            }, 100);
+        }
+    }
+
+    return () => {
+        // clear interval on unmount
+        clearInterval(intervalRef.current)
+    };
+
+  }, []);
+
+
+  return (
+    (attributorData !== undefined) && 
+    <>
+        <input type="hidden" name="retURL" value={returnUrl} />
+
+        <input type="hidden" name="channel" value={attributorData.drillData.channel} />
+        <input type="hidden" name="drillDown1" value={attributorData.drillData.drillDown1} />
+        <input type="hidden" name="drillDown2" value={attributorData.drillData.drillDown2} />
+        <input type="hidden" name="drillDown3" value={attributorData.drillData.drillDown3} />
+        <input type="hidden" name="drillDown4" value={attributorData.drillData.drillDown4} />
+        <input type="hidden" name="gclid" value={attributorData.gclid} />
+        <input type="hidden" name="landingpage" value={attributorData.landing_url} />
+        <input type="hidden" name="landingpagegroup" value={attributorData.landing_page_group} />
+    </>
+  )
+}
+
+Lead.propTypes = {
+  returnUrl: PropTypes.string.isRequired,
+}

--- a/src/components/AttributorFields/index.js
+++ b/src/components/AttributorFields/index.js
@@ -35,14 +35,14 @@ export default function Lead ({returnUrl}) {
     <>
         <input type="hidden" name="retURL" value={returnUrl} />
 
-        <input type="hidden" name="utm-channel" value={attributorData.drillData.channel} />
-        <input type="hidden" name="utm-drillDown1" value={attributorData.drillData.drillDown1} />
-        <input type="hidden" name="utm-drillDown2" value={attributorData.drillData.drillDown2} />
-        <input type="hidden" name="utm-drillDown3" value={attributorData.drillData.drillDown3} />
-        <input type="hidden" name="utm-drillDown4" value={attributorData.drillData.drillDown4} />
-        <input type="hidden" name="utm-gclid" value={attributorData.gclid} />
-        <input type="hidden" name="utm-landingpage" value={attributorData.landing_url} />
-        <input type="hidden" name="utm-landingpagegroup" value={attributorData.landing_page_group} />
+        <input type="hidden" name="oid" value="00D8d000009pkmx"/>
+        <input type="hidden" name="00N8d00000QN3Qa" value={attributorData?.drillData?.channel || ""} />
+        <input type="hidden" name="00N8d00000QN3Qf" value={attributorData?.drillData?.drillDown1 || ""} />
+        <input type="hidden" name="00N8d00000QN3Qk" value={attributorData?.drillData?.drillDown2 || ""} />
+        <input type="hidden" name="00N8d00000QN3Qp" value={attributorData?.drillData?.drillDown3 || ""} />
+        <input type="hidden" name="00N8d00000QN4dw" value={attributorData?.drillData?.drillDown4 || ""} />
+        <input type="hidden" name="00N8d00000QN3Qu" value={attributorData?.landing_url || ""} />
+        <input type="hidden" name="00N8d00000QN3Qu" value={attributorData?.landing_page_group || ""} />
     </>
   )
 }

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -186,12 +186,6 @@ const Layout = (props) => {
               `}
             </script>
             <script>
-              {`
-                <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T35RVN5"
-                height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-              `}
-            </script>
-            <script>
             {`
               (function(e,a){
                 var t,r=e.getElementsByTagName("head")[0],c=e.location.protocol;
@@ -269,12 +263,6 @@ const Layout = (props) => {
                 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
                 })(window,document,'script','dataLayer','GTM-T35RVN5');
-              `}
-            </script>
-            <script>
-              {`
-                <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T35RVN5"
-                height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
               `}
             </script>
             <script>
@@ -364,12 +352,6 @@ const Layout = (props) => {
         </script>
         <script>
           {`
-            <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T35RVN5"
-            height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-          `}
-        </script>
-        <script>
-          {`
             !function(){var t,o,c,e=window,n=document,r=arguments,a="script",i=["call","cancelAction","config","identify","push","track","trackClick","trackForm","update","visit"],s=function(){var t,o=this,c=function(t){o[t]=function(){return o._e.push([t].concat(Array.prototype.slice.call(arguments,0))),o}};for(o._e=[],t=0;t<i.length;t++)c(i[t])};for(e.__woo=e.__woo||{},t=0;t<r.length;t++)e.__woo[r[t]]=e[r[t]]=e[r[t]]||new s;(o=n.createElement(a)).async=1,o.src="https://static.woopra.com/js/w.js",(c=n.getElementsByTagName(a)[0]).parentNode.insertBefore(o,c)}("woopra");
             woopra.config({
             domain: "strategically.co",
@@ -434,12 +416,6 @@ const Layout = (props) => {
             j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
             })(window,document,'script','dataLayer','GTM-T35RVN5');
-          `}
-        </script>
-        <script>
-          {`
-            <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T35RVN5"
-            height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
           `}
         </script>
         <script>
@@ -520,12 +496,6 @@ const Layout = (props) => {
         </script>
         <script>
           {`
-            <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T35RVN5"
-            height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-          `}
-        </script>
-        <script>
-          {`
             (function(e,a){
               var t,r=e.getElementsByTagName("head")[0],c=e.location.protocol;
               t=e.createElement("script");t.type="text/javascript";
@@ -597,12 +567,6 @@ const Layout = (props) => {
             j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
             })(window,document,'script','dataLayer','GTM-T35RVN5');
-          `}
-        </script>
-        <script>
-          {`
-            <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T35RVN5"
-            height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
           `}
         </script>
         <script>
@@ -697,12 +661,6 @@ const Layout = (props) => {
         </script>
         <script>
           {`
-            <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T35RVN5"
-            height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-          `}
-        </script>
-        <script>
-          {`
             (function(e,a){
               var t,r=e.getElementsByTagName("head")[0],c=e.location.protocol;
               t=e.createElement("script");t.type="text/javascript";
@@ -793,12 +751,6 @@ const Layout = (props) => {
         </script>
         <script>
           {`
-            <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T35RVN5"
-            height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-          `}
-        </script>
-        <script>
-          {`
             (function(e,a){
               var t,r=e.getElementsByTagName("head")[0],c=e.location.protocol;
               t=e.createElement("script");t.type="text/javascript";
@@ -874,12 +826,6 @@ const Layout = (props) => {
             j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
             'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
             })(window,document,'script','dataLayer','GTM-T35RVN5');
-          `}
-        </script>
-        <script>
-          {`
-            <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T35RVN5"
-            height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
           `}
         </script>
         <script>
@@ -1031,12 +977,6 @@ const Layout = (props) => {
               `}
             </script>
             <script>
-              {`
-                <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T35RVN5"
-                height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-              `}
-            </script>
-            <script>
             {`
               (function(e,a){
                 var t,r=e.getElementsByTagName("head")[0],c=e.location.protocol;
@@ -1091,7 +1031,7 @@ const Layout = (props) => {
             <link rel="icon" type="image/png" href={imgFavicon} />
             <script type="application/ld+json">{JSON.stringify(schemaOrgJSONLD)}</script>
             <body data-theme={gContext.theme.bodyDark ? "dark" : "light"} />
-            <script>window.STONLY_WID = "d4b28c86-9895-11ec-9fb8-0ae9fa2a18a2";</script>
+            <script>{` window.STONLY_WID = "d4b28c86-9895-11ec-9fb8-0ae9fa2a18a2"; `}</script>
             <script>
              {`
               window.__kl__tr__Id='629ae3fb9d9831001ffb4530',function(){var t=document.createElement('script');t.type='text/javascript',t.async=!0,t.src='https://s3-us-west-2.amazonaws.com/kl-website-tracking/klenty_track.js';var e=document.getElementsByTagName('script')[0];e.parentNode.insertBefore(t,e)}();
@@ -1123,12 +1063,6 @@ const Layout = (props) => {
                 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
                 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
                 })(window,document,'script','dataLayer','GTM-T35RVN5');
-              `}
-            </script>
-            <script>
-              {`
-                <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T35RVN5"
-                height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
               `}
             </script>
             <script>
@@ -1194,7 +1128,6 @@ const Layout = (props) => {
             </div>
             
           </CookieConsent>
-
         </>
       </>
     );

--- a/src/html.js
+++ b/src/html.js
@@ -23,16 +23,12 @@ export default function HTML(props) {
         />
         <script type="text/javascript" src="https://d1b3llzbo1rqxo.cloudfront.net/attributer.js"></script>
         {props.postBodyComponents}
-        <script>
-        {`
-        _linkedin_partner_id = "4460818"; window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || []; window._linkedin_data_partner_ids.push(_linkedin_partner_id);
-        `}
-        </script>  
-        <script>
-        {`
-        (function(l) { if (!l){window.lintrk = function(a,b){window.lintrk.q.push([a,b])}; window.lintrk.q=[]} var s = document.getElementsByTagName("script")[0]; var b = document.createElement("script"); b.type = "text/javascript";b.async = true; b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js"; s.parentNode.insertBefore(b, s);})(window.lintrk);
-        `}
-        </script>          
+        <script dangerouslySetInnerHTML={{__html:
+          `_linkedin_partner_id = "4460818"; window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || []; window._linkedin_data_partner_ids.push(_linkedin_partner_id);`
+        }} />  
+        <script dangerouslySetInnerHTML={{__html:
+          `(function(l) { if (!l){window.lintrk = function(a,b){window.lintrk.q.push([a,b])}; window.lintrk.q=[]} var s = document.getElementsByTagName("script")[0]; var b = document.createElement("script"); b.type = "text/javascript";b.async = true; b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js"; s.parentNode.insertBefore(b, s);})(window.lintrk);`
+        }} />          
         <noscript><img height="1" width="1" style={{display:"none"}} alt="" src="https://px.ads.linkedin.com/collect/?pid=4460818&fmt=gif" /></noscript>                
         
       </body>

--- a/src/html.js
+++ b/src/html.js
@@ -30,7 +30,7 @@ export default function HTML(props) {
           `(function(l) { if (!l){window.lintrk = function(a,b){window.lintrk.q.push([a,b])}; window.lintrk.q=[]} var s = document.getElementsByTagName("script")[0]; var b = document.createElement("script"); b.type = "text/javascript";b.async = true; b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js"; s.parentNode.insertBefore(b, s);})(window.lintrk);`
         }} />          
         <noscript><img height="1" width="1" style={{display:"none"}} alt="" src="https://px.ads.linkedin.com/collect/?pid=4460818&fmt=gif" /></noscript>                
-        
+        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-T35RVN5" height="0" width="0" style={{display:"none",visibility:"hidden"}}></iframe></noscript>
       </body>
     </html>
   )

--- a/src/pages/calculate-content-roi.js
+++ b/src/pages/calculate-content-roi.js
@@ -1,7 +1,8 @@
-
 import React, { useEffect} from 'react';
 import { Helmet } from "react-helmet";
 import LeadgenLayout from "../components/Layout/LeadgenLayout";
+import AttributorFields from "../components/AttributorFields";
+
 const LeadgenPageMaster = () => {
     useEffect(() => {
         setInterval(() => {
@@ -19,15 +20,7 @@ const LeadgenPageMaster = () => {
             >
                 <div class="container mx-auto p-0">
                 <form action="https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8" method="POST">
-                        <input type="hidden" name="oid" value="00D8d000009pkmx"/>
-                        <input type="hidden" name="retURL" value="https://strategically.co/calculator/content-marketing-roi/"/>
-                        <input type="hidden" name="00N8d00000QN3Qa" id="00N8d00000QN3Qa" value="[channel]" />
-                        <input type="hidden" name="00N8d00000QN3Qf" id="00N8d00000QN3Qf" value="[channeldrilldown1]" />
-                        <input type="hidden" name="00N8d00000QN3Qk" id="00N8d00000QN3Qk" value="[channeldrilldown2]" />
-                        <input type="hidden" name="00N8d00000QN3Qp" id="00N8d00000QN3Qp" value="[channeldrilldown3]" />
-                        <input type="hidden" name="00N8d00000QN4dw" id="00N8d00000QN4dw" value="[channeldrilldown4]" />
-                        <input type="hidden" name="00N8d00000QN3Qu" id="00N8d00000QN3Qu" value="[landingpage]" />
-                        <input type="hidden" name="00N8d00000QN3Qz" id="00N8d00000QN3Qz" value="[landingpagegroup]" />
+                    <AttributorFields returnUrl="https://strategically.co/calculator/content-marketing-roi/" />
 
                         <div className="form-group position-relative mb-4">
                             <input

--- a/src/pages/contact.js
+++ b/src/pages/contact.js
@@ -11,6 +11,8 @@ import {
   Honeypot
 } from 'react-netlify-forms'
 import LeadgenLayout from "../components/Layout/LeadgenLayout";
+import AttributorFields from "../components/AttributorFields";
+
 const Contact = () => {
   const { register, handleSubmit, handleChange, control, formState: { errors } } = useForm();
   //
@@ -42,12 +44,6 @@ const Contact = () => {
     netlify.handleSubmit(null, data)
   }
 
-  useEffect(() => {
-    setInterval(() => {
-        document.FlareTrk.repop();
-    }, 1000);
-  }, []);
-
   return (
     <>
       <Helmet>
@@ -59,15 +55,7 @@ const Contact = () => {
       >
         <div class="container mx-auto p-0">
           <form action="https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8" method="POST">
-            <input type="hidden" name="oid" value="00D8d000009pkmx"/>
-            <input type="hidden" name="retURL" value="https://strategically.co/thank-you/"/>
-            <input type="hidden" name="00N8d00000QN3Qa" id="00N8d00000QN3Qa" value="[channel]" />
-            <input type="hidden" name="00N8d00000QN3Qf" id="00N8d00000QN3Qf" value="[channeldrilldown1]" />
-            <input type="hidden" name="00N8d00000QN3Qk" id="00N8d00000QN3Qk" value="[channeldrilldown2]" />
-            <input type="hidden" name="00N8d00000QN3Qp" id="00N8d00000QN3Qp" value="[channeldrilldown3]" />
-            <input type="hidden" name="00N8d00000QN4dw" id="00N8d00000QN4dw" value="[channeldrilldown4]" />
-            <input type="hidden" name="00N8d00000QN3Qu" id="00N8d00000QN3Qu" value="[landingpage]" />
-            <input type="hidden" name="00N8d00000QN3Qz" id="00N8d00000QN3Qz" value="[landingpagegroup]" />
+            <AttributorFields returnUrl="https://strategically.co/thank-you/" />
 
             <div className="form-group position-relative mb-4">
               <input

--- a/src/pages/free-seo-audit.js
+++ b/src/pages/free-seo-audit.js
@@ -2,6 +2,8 @@
 import React, { useEffect } from 'react';
 import { Helmet } from "react-helmet";
 import LeadgenLayout from "../components/Layout/LeadgenLayout";
+import AttributorFields from "../components/AttributorFields";
+
 const LeadgenPageMaster = () => {
     useEffect(() => {
         setInterval(() => {
@@ -19,15 +21,7 @@ const LeadgenPageMaster = () => {
             >
                 <div class="container mx-auto p-0">
                 <form action="https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8" method="POST">
-                        <input type="hidden" name="oid" value="00D8d000009pkmx"/>
-                        <input type="hidden" name="retURL" value="https://strategically.co/thank-you-audit/"/>
-                        <input type="hidden" name="00N8d00000QN3Qa" id="00N8d00000QN3Qa" value="[channel]" />
-                        <input type="hidden" name="00N8d00000QN3Qf" id="00N8d00000QN3Qf" value="[channeldrilldown1]" />
-                        <input type="hidden" name="00N8d00000QN3Qk" id="00N8d00000QN3Qk" value="[channeldrilldown2]" />
-                        <input type="hidden" name="00N8d00000QN3Qp" id="00N8d00000QN3Qp" value="[channeldrilldown3]" />
-                        <input type="hidden" name="00N8d00000QN4dw" id="00N8d00000QN4dw" value="[channeldrilldown4]" />
-                        <input type="hidden" name="00N8d00000QN3Qu" id="00N8d00000QN3Qu" value="[landingpage]" />
-                        <input type="hidden" name="00N8d00000QN3Qz" id="00N8d00000QN3Qz" value="[landingpagegroup]" />
+                    <AttributorFields returnUrl="https://strategically.co/thank-you-audit/" />
 
                         <div className="form-group position-relative mb-4">
                             <input

--- a/src/pages/get-a-quote.js
+++ b/src/pages/get-a-quote.js
@@ -1,12 +1,10 @@
 import React, { useEffect } from "react"
 import { Helmet } from "react-helmet";
 import LeadgenLayout from "../components/Layout/LeadgenLayout";
+import AttributorFields from "../components/AttributorFields";
+
 const GetAQuote = (props) => {
-    useEffect(() => {
-        setInterval(() => {
-            document.FlareTrk.repop();
-        }, 1000);
-      }, []);
+
     return (
         <>
             <Helmet>
@@ -18,15 +16,7 @@ const GetAQuote = (props) => {
             >
                 <div class="container mx-auto p-0">
                     <form action="https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8" method="POST">
-                        <input type="hidden" name="oid" value="00D8d000009pkmx" />
-                        <input type="hidden" name="retURL" value="https://strategically.co/success" />
-                        <input type="hidden" name="00N8d00000QN3Qa" id="00N8d00000QN3Qa" value="[channel]" />
-                        <input type="hidden" name="00N8d00000QN3Qf" id="00N8d00000QN3Qf" value="[channeldrilldown1]" />
-                        <input type="hidden" name="00N8d00000QN3Qk" id="00N8d00000QN3Qk" value="[channeldrilldown2]" />
-                        <input type="hidden" name="00N8d00000QN3Qp" id="00N8d00000QN3Qp" value="[channeldrilldown3]" />
-                        <input type="hidden" name="00N8d00000QN4dw" id="00N8d00000QN4dw" value="[channeldrilldown4]" />
-                        <input type="hidden" name="00N8d00000QN3Qu" id="00N8d00000QN3Qu" value="[landingpage]" />
-                        <input type="hidden" name="00N8d00000QN3Qz" id="00N8d00000QN3Qz" value="[landingpagegroup]" />
+                        <AttributorFields returnUrl="https://strategically.co/success" />
                         <div className="form-group position-relative mb-4">
                             <input
                                 id="first_name"

--- a/src/pages/get-free-content-samples.js
+++ b/src/pages/get-free-content-samples.js
@@ -2,12 +2,10 @@
 import React, { useEffect } from 'react';
 import { Helmet } from "react-helmet";
 import LeadgenLayout from "../components/Layout/LeadgenLayout";
+import AttributorFields from "../components/AttributorFields";
+
 const LeadgenPageMaster = () => {
-    useEffect(() => {
-        setInterval(() => {
-            document.FlareTrk.repop();
-        }, 1000);
-      }, []);
+
     return (
         <>
             <Helmet>
@@ -18,16 +16,7 @@ const LeadgenPageMaster = () => {
                 description=" Want to check out samples specific to your niche? Get free samples for any industry or content type, written by our 5-star writers. ">
                 <div class="container mx-auto p-0">
                 <form action="https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8" method="POST">
-                <input type="hidden" name="oid" value="00D8d000009pkmx"/>
-                <input type="hidden" name="retURL" value="https://strategically.co/thank-you-samples/"/>
-                <input type="hidden" name="00N8d00000QN3Qa" id="00N8d00000QN3Qa" value="[channel]" />
-                <input type="hidden" name="00N8d00000QN3Qf" id="00N8d00000QN3Qf" value="[channeldrilldown1]" />
-                <input type="hidden" name="00N8d00000QN3Qk" id="00N8d00000QN3Qk" value="[channeldrilldown2]" />
-                <input type="hidden" name="00N8d00000QN3Qp" id="00N8d00000QN3Qp" value="[channeldrilldown3]" />
-                <input type="hidden" name="00N8d00000QN4dw" id="00N8d00000QN4dw" value="[channeldrilldown4]" />
-                <input type="hidden" name="00N8d00000QN3Qu" id="00N8d00000QN3Qu" value="[landingpage]" />
-                <input type="hidden" name="00N8d00000QN3Qz" id="00N8d00000QN3Qz" value="[landingpagegroup]" />
-
+                    <AttributorFields returnUrl="https://strategically.co/thank-you-samples/" />
                     <div className="form-group position-relative mb-4">
                         <input
                             id="first_name"

--- a/src/pages/get-ten-free-topic-ideas.js
+++ b/src/pages/get-ten-free-topic-ideas.js
@@ -2,6 +2,8 @@
 import React, { useEffect } from 'react';
 import { Helmet } from "react-helmet";
 import LeadgenLayout from "../components/Layout/LeadgenLayout";
+import AttributorFields from "../components/AttributorFields";
+
 const LeadgenPageMaster = () => {
     useEffect(() => {
         setInterval(() => {
@@ -19,15 +21,7 @@ const LeadgenPageMaster = () => {
             >
                 <div class="container mx-auto p-0">
                 <form action="https://webto.salesforce.com/servlet/servlet.WebToLead?encoding=UTF-8" method="POST">
-                        <input type="hidden" name="oid"  value="00D8d000009pkmx" />
-                        <input type="hidden" name="retURL" value="https://strategically.co/thank-you-topic-ideation/" />
-                        <input type="hidden" name="00N8d00000QN3Qa" id="00N8d00000QN3Qa" value="[channel]" />
-                        <input type="hidden" name="00N8d00000QN3Qf" id="00N8d00000QN3Qf" value="[channeldrilldown1]" />
-                        <input type="hidden" name="00N8d00000QN3Qk" id="00N8d00000QN3Qk" value="[channeldrilldown2]" />
-                        <input type="hidden" name="00N8d00000QN3Qp" id="00N8d00000QN3Qp" value="[channeldrilldown3]" />
-                        <input type="hidden" name="00N8d00000QN4dw" id="00N8d00000QN4dw" value="[channeldrilldown4]" />
-                        <input type="hidden" name="00N8d00000QN3Qu" id="00N8d00000QN3Qu" value="[landingpage]" />
-                        <input type="hidden" name="00N8d00000QN3Qz" id="00N8d00000QN3Qz" value="[landingpagegroup]" />
+                    <AttributorFields returnUrl="https://strategically.co/thank-you-topic-ideation/" />
 
                         <div className="form-group position-relative mb-4">
                             <input


### PR DESCRIPTION
This pull request ensures that the hidden UTM fields for the contact forms will always be populated.

This still uses the Attributor script, but no longer depends on it to update the `input` values. That is now performed using React state, with the data from Attributor.
 
The fields are no longer named with obfuscated names like `00N8d00000QN3Qa`, but now use names like "utm-channel", "utm-drilldown1" etc. I did this for clarity while working on it, but we can revert to the obfuscated field names easily if preferred.

It also includes some small fixes relating to loading external JS, which was causing console errors.